### PR TITLE
__nextcloud upgrading safety check

### DIFF
--- a/type/__nextcloud/gencode-remote
+++ b/type/__nextcloud/gencode-remote
@@ -81,6 +81,9 @@ REMOTE
 
     # no more changes from the user
     occ_maintainer_mode_on
+    # updater will care about required app updates
+
+    # do the real update work
     cat << REMOTE
 
 cp -pf '$installdir/config/config.php' '$tarballdir/config/config.php'

--- a/type/__nextcloud/man.rst
+++ b/type/__nextcloud/man.rst
@@ -31,6 +31,17 @@ version
     upgraded via the built-in nextcloud installer. In such cases, it is
     recommended to use the ``--install-only`` option.
 
+    You should only upgrade to the next major release from the latest point
+    release (latest release available in that major); see the `how to upgrade
+    Guide <https://docs.nextcloud.com/server/latest/admin_manual/maintenance/upgrade.html>`
+    from the official Nextcloud documentation. This type will prevent skipping
+    major releases except the check is explicitly disabled through the
+    ``--disable-version-check`` parameter.
+
+    Currently, no loop is implemented to do these upgrades automaticly for you,
+    as the type does not implement any version knowledge. Manifest must be
+    changed and cdist needs to be rerun to get to the correct version you need.
+
 admin-password
     The administrator password to access the nextcloud instance. Must be given
     in plain text. This parameter has no effect if nextcloud will not be
@@ -62,6 +73,14 @@ BOOLEAN PARAMETERS
 install-only
     Skips all nextcloud upgrades done by this type. Should be used when
     nextcloud upgrades are (*exclusively*) done via the built-in updater.
+
+disable-version-check
+    Disables the version security checks that avoid breaking your Nextcloud.
+    Only do this on your own risks, as it can seriously break your instance.
+
+    Is this parameter omitted, the type will check if the new major version
+    gap is greather than 1. It will not perform more fine-tuned version checks
+    cause of a lack of more detailed versioning data.
 
 
 NEXTCLOUD CONFIG PARAMETERS

--- a/type/__nextcloud/manifest
+++ b/type/__nextcloud/manifest
@@ -24,7 +24,7 @@ version_ge() {
             exit (diff < 0)
         }
         exit 1
-    }'; return $?
+    }'
 }
 
 # Version compare function if the major version is too different (only upwards)
@@ -42,9 +42,8 @@ version_majdiff() {
         getline
         split($1, x, ".")
         split(target, y, ".")
-        if((y[1] - x[1]) > 1) exit 0
-        else exit 1
-    }'; return $?
+        exit (y[1] - x[1] <= 1)
+    }'
 }
 
 

--- a/type/__nextcloud/manifest
+++ b/type/__nextcloud/manifest
@@ -27,6 +27,26 @@ version_ge() {
     }'; return $?
 }
 
+# Version compare function if the major version is too different (only upwards)
+#
+# Arguments:
+#  1: curr version
+#  2: new version
+#
+# Return code:
+#  0: major difference bigger than 1
+#  1: major not bigger than 1
+version_majdiff() {
+    printf "%s" "$1" | awk -F '[^0-9.]' -v target="$2" '
+    BEGIN {
+        getline
+        nx = split($1, x, ".")
+        ny = split(target, y, ".")
+        if((ny[1] - nx[1]) > 1) exit 0
+        else exit 1
+    }'; return $?
+}
+
 
 # Check support status
 os="$(cat "$__global/explorer/os")"
@@ -103,10 +123,23 @@ if [ "$version_is" ]; then
         # if the current version is higher than the version that should be installed
         if version_ge "$version_is" "$version_should"; then
             # it's an error if the current version is higher than the one that should be installed
-            printf "The current nextcloud version '%s' is higher than the version that should be installed (%s)\n" \
+            printf "The current Nextcloud version '%s' is higher than the version that should be installed (%s)\n" \
                "$version_is" "$version_should" >&2
             printf "Please bump the nextcloud version to '%s' or higher!\n" "$version_is" >&2
             exit 2
+        fi
+
+        # Block upgrades for too great Nextcloud upgrades
+        if ! [ -f "$__object/parameter/disable-version-check" ]; then
+            if version_majdiff "$version_is" "$version_should"; then
+                # error for your safety
+                printf "The new Nextcloud version '%s' is bigger than the next major release from the current release '%s'!\n" \
+                   "$version_should" "$version_is" >&2
+                printf "Skipping major releases is discoraged from upstream as this can seriously break your instance. If you really want, use --disable-version-check (dangerous)\n" >&2
+                printf "Instead, upgrade your instance to the latest point release in the current major and then upgrade to the next latest major version.\n" >&2
+                printf "for more information, see type manual parameter --version\n" >&2
+                exit 3
+            fi
         fi
 
         # Set destination to a temporary directory

--- a/type/__nextcloud/manifest
+++ b/type/__nextcloud/manifest
@@ -40,9 +40,9 @@ version_majdiff() {
     printf "%s" "$1" | awk -F '[^0-9.]' -v target="$2" '
     BEGIN {
         getline
-        nx = split($1, x, ".")
-        ny = split(target, y, ".")
-        if((ny[1] - nx[1]) > 1) exit 0
+        split($1, x, ".")
+        split(target, y, ".")
+        if((y[1] - x[1]) > 1) exit 0
         else exit 1
     }'; return $?
 }

--- a/type/__nextcloud/parameter/boolean
+++ b/type/__nextcloud/parameter/boolean
@@ -1,1 +1,2 @@
 install-only
+disable-version-check


### PR DESCRIPTION
This change brings some improvements for the manual and a check that avoid too big version jumps (but can be skipped with a parameter).

Tested it with upgrades for two Nextcloud instances without problems.