### PR TITLE
__netbox: fix pip3 install error on newer versions

### DIFF
--- a/type/__netbox/gencode-remote
+++ b/type/__netbox/gencode-remote
@@ -51,7 +51,9 @@ fi
 # Install python dependencies.
 #  avoid gunicorn, because it will be done in an other type
 grep -v "^gunicorn==" "\$tmpdir/$src/requirements.txt" \
-    | xargs /opt/netbox/venv/bin/pip3 install -q
+    > "\$tmpdir/$src/requirements.txt.new"
+/opt/netbox/venv/bin/pip3 install -q -r "\$tmpdir/$src/requirements.txt.new"
+
 EOF
 
     if [ -f "$__object/parameter/ldap-server" ]; then

--- a/type/__netbox/man.rst
+++ b/type/__netbox/man.rst
@@ -31,6 +31,12 @@ version
     on GitHub at the NetBox project page under
     "`Releases <https://github.com/netbox-community/netbox/releases>`_".
 
+    Too big version jumps can break the NetBox migration path. It's good
+    practise to don't skip major versions and common that you must upgrade to
+    the latest minor inside the current major version till you can upgrade to
+    the next major version. Diffrent version steps must be done manually as
+    this type only upgrades to the given version directly.
+
 database
     PostgreSQL database name.
 


### PR DESCRIPTION
A comment in the `requirements.txt` made problems when it was introduced via v3.0.5. This PR should fix it by using the pip `requirements.txt` parsing instead of passing it to pip via xargs arguments.

I've also added a manpage note about skipping versions, as this happend to me :-)