### PR TITLE
__netbox: remove removed migration command in 3.0.0

### DIFF
--- a/type/__netbox/gencode-remote
+++ b/type/__netbox/gencode-remote
@@ -84,8 +84,6 @@ sudo -u netbox /opt/netbox/venv/bin/python3 /opt/netbox/netbox/manage.py collect
 sudo -u netbox /opt/netbox/venv/bin/python3 /opt/netbox/netbox/manage.py remove_stale_contenttypes --no-input
 # Delete any expired user sessions
 sudo -u netbox /opt/netbox/venv/bin/python3 /opt/netbox/netbox/manage.py clearsessions
-# Clear all cached data
-sudo -u netbox /opt/netbox/venv/bin/python3 /opt/netbox/netbox/manage.py invalidate all
 
 # Remove temporary working directory.
 cd /


### PR DESCRIPTION
The `invalidate all` mangement-command no longer exists in NetBox version 3.0.0 and above. It's now removed for configuration. This type currently don't work for versions >= 3.0.0, which is fixed by this PR.