### PR TITLE
__smartd: Add support for NetBSD

### DIFF
--- a/type/__smartd/explorer/mailer
+++ b/type/__smartd/explorer/mailer
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020 Dennis Camera (dennis.camera at riiengineering.ch)
+# 2020,2025 Dennis Camera (dennis.camera at riiengineering.ch)
 #
 # This file is part of skonfig-extra.
 #
@@ -17,14 +17,27 @@
 # You should have received a copy of the GNU General Public License
 # along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
 #
-# Determine which command to use to send e-mail.
+# Determine which command can be used to send e-mail.
 #
 
-# NOTE: path is hard-coded in /etc/smartmontools/run.d/10mail on Debian
-if test -x /usr/bin/mail
+if test -f /etc/smartmontools/run.d/10mail
 then
-	echo mail
-elif command -v sendmail >/dev/null 2>&1
-then
-	echo sendmail
+	# NOTE: Debian, special case because mail(1) path is hard-coded in
+	#       /etc/smartmontools/run.d/10mail
+	if test -x /usr/bin/mail
+	then
+		echo mail
+	elif command -v sendmail >/dev/null 2>&1
+	then
+		echo sendmail
+	fi
+else
+	if command -v mail >/dev/null 2>&1
+	then
+		echo mail
+	elif command -v sendmail >/dev/null 2>&1
+	then
+		echo sendmail
+	fi
+
 fi

--- a/type/__smartd/gencode-remote
+++ b/type/__smartd/gencode-remote
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+#
+# 2025 Dennis Camera (dennis.camera at riiengineering.ch)
+#
+# This file is part of skonfig-extra.
+#
+# skonfig-extra is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# skonfig-extra is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with skonfig-extra. If not, see <http://www.gnu.org/licenses/>.
+#
+
+os=$(cat "${__global:?}/explorer/os")
+
+case ${os}
+in
+	(netbsd)
+		if grep -qxF '__package_pkgsrc/smartmontools:installed' "${__messages_in:?}"
+		then
+			# NetBSD/pkgsrc does not install the rc.d script automatically, so
+			# it needs to be done manually after the package installation,
+			# if it does not exist already.
+			cat <<-'EOF'
+			test -f /etc/rc.d/smartd || install -m 0555 /usr/pkg/share/examples/rc.d/smartd /etc/rc.d
+			EOF
+		fi
+		;;
+esac

--- a/type/__smartd/manifest
+++ b/type/__smartd/manifest
@@ -64,7 +64,7 @@ in
 		in
 			(present)
 				# taken from Debian, seems to make sense :-)
-				devicescan_options='-d removable -n standby -m root'
+				devicescan_options='-a -d removable -n standby -m root'
 
 				# NOTE: sync with NetBSD
 				require=__package_apk/smartmontools \
@@ -140,7 +140,7 @@ in
 		in
 			(present)
 				# taken from Debian, seems to make sense :-)
-				devicescan_options='-d removable -n standby -m root'
+				devicescan_options='-a -d removable -n standby -m root'
 
 				# NOTE: sync with Alpine Linux
 				require=__package_pkgsrc/smartmontools \

--- a/type/__smartd/manifest
+++ b/type/__smartd/manifest
@@ -63,16 +63,17 @@ in
 		case ${state_should}
 		in
 			(present)
-				# tanken from Debian, seems to make sense :-)
+				# taken from Debian, seems to make sense :-)
 				devicescan_options='-d removable -n standby -m root'
 
+				# NOTE: sync with NetBSD
 				require=__package_apk/smartmontools \
 				__sed /etc/smartd.conf:DEVICESCAN \
 					--file /etc/smartd.conf \
 					--script '1,/^DEVICESCAN/s#^DEVICESCAN.*$#DEVICESCAN '"${devicescan_options-}"'#' \
 					--onchange 'killall -HUP smartd'  # reload config
 
-				require='__package_apk/smartmontools __sed/etc/smartd.conf:DEVICESCAN' \
+				require='__package_apk/smartmontools' \
 				__start_on_boot smartd
 				;;
 		esac
@@ -117,7 +118,7 @@ in
 		case ${state_should}
 		in
 			(present)
-				# Enable smartd
+				# enable smartd
 				# https://salsa.debian.org/debian/smartmontools/-/commit/f1420bd#9c96da0e9f91d7d8937b69b524702c106258f0d1_13_15
 				require=__package_apt/smartmontools \
 				__key_value /etc/default/smartmontools:start_smartd \
@@ -131,10 +132,32 @@ in
 				;;
 		esac
 		;;
+	(netbsd)
+		__package_pkgsrc smartmontools \
+			--state "${state_should}"
+
+		case ${state_should}
+		in
+			(present)
+				# taken from Debian, seems to make sense :-)
+				devicescan_options='-d removable -n standby -m root'
+
+				# NOTE: sync with Alpine Linux
+				require=__package_pkgsrc/smartmontools \
+				__sed /usr/pkg/etc/smartd.conf:DEVICESCAN \
+					--file /usr/pkg/etc/smartd.conf \
+					--script '1,/^DEVICESCAN/s#^DEVICESCAN.*$#DEVICESCAN '"${devicescan_options-}"'#' \
+					--onchange 'pkill -HUP smartd'  # reload config
+
+				require="__package_pkgsrc/smartmontools ${__object_name:?}" \
+				__start_on_boot smartd
+				;;
+		esac
+		;;
 	(*)
 		: "${__type:?}"  # make shellcheck happy
-		printf "Your operating system (%s) is currently not supported by this type (%s)\n" "${os}" "${__type##*/}" >&2
-		printf "Please contribute an implementation for it if you can.\n" >&2
+		printf 'Your operating system (%s) is currently not supported by this type (%s)\n' "${os}" "${__type##*/}" >&2
+		printf 'Please contribute an implementation for it if you can.\n' >&2
 		exit 1
 		;;
 esac


### PR DESCRIPTION
As the title says, extend the `__smartd` type for NetBSD.

I updated the `DEVICESCAN` configuration line for Alpine Linux as well:

> If no monitoring directives are set in the DEVICESCAN line, then smartmontools implicitly sets all of them and prints the log line:
> 
>     smartd[29362]: Drive: DEVICESCAN, implied '-a' Directive on line 23 of file /usr/pkg/etc/smartd.conf
> 
> Instead of relying on implicit smartmontools behaviour, let's be explicit with what we want.

And made the `mailer` detection code for Debian specific to Debian, because other OSes tend to use the upstream `smartd_warning.sh` script as is (hard-coded `/usr/bin/mail`).